### PR TITLE
Handle tokens that do not report a serial number

### DIFF
--- a/OpenSCToken/Token.m
+++ b/OpenSCToken/Token.m
@@ -190,7 +190,9 @@
         [items addObject:keyItem];
     }
 
-    instanceID = [NSString stringWithUTF8String:p15card->tokeninfo->serial_number];
+    /* some tokens do not report a serial number */
+    if (p15card->tokeninfo != NULL && p15card->tokeninfo->serial_number != NULL)
+        instanceID = [NSString stringWithUTF8String:p15card->tokeninfo->serial_number];
     p15card->opts.use_pin_cache = 0;
     
     if (self = [super initWithSmartCard:smartCard AID:AID instanceID:instanceID tokenDriver:tokenDriver]) {


### PR DESCRIPTION
At least one specific implementation of CardOS5 cards does not seem to
report a serial number which makes OpenSCToken terminate with:

OpenSCToken: (CoreFoundation) *** Terminating app due to uncaught
exception 'NSInvalidArgumentException', reason: '*** +[NSString
stringWithUTF8String:]: NULL cString'

This change makes OpenSCToken work for these cards as well.