### PR TITLE
Add missing break

### DIFF
--- a/OpenSCToken/TokenSession.m
+++ b/OpenSCToken/TokenSession.m
@@ -246,7 +246,7 @@ err:
                 default:
                     return nil;
             }
-			break;
+            break;
         default:
             return nil;
     }

--- a/OpenSCToken/TokenSession.m
+++ b/OpenSCToken/TokenSession.m
@@ -246,6 +246,7 @@ err:
                 default:
                     return nil;
             }
+			break;
         default:
             return nil;
     }


### PR DESCRIPTION
For keys of type `SC_PKCS15_TYPE_PRKEY_EC`, there is no `break`, meaning the execution continues to the next labeled statement, here `default`, and `return nil` is always executed.

Signed-off-by: El Mostafa IDRASSI <el-mostafa.idrassi@prestalab.net>